### PR TITLE
Feat: checkSession behave like isAuthenticated and change constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 *.log
 .DS_Store
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.log
 .DS_Store
 .idea
+.history

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ export const loader: LoaderFunction = async({ request }) =>
 ```js
 // app/routes/login.ts
 export const loader = async ({ request }) => {
-    const redirectTo = new URL(request.url).searchParams.get("redirectTo") ?? "dashboard";
+    const redirectTo = new URL(request.url).searchParams.get("redirectTo") ?? "/dashboard";
 
     return supabaseStrategy.checkSession(request, {
         successRedirect: redirectTo,

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Remix Auth - Supabase Strategy
+****# Remix Auth - Supabase Strategy
 
 > Strategy for using supabase with Remix Auth
 
@@ -19,18 +19,21 @@ The way remix-auth (and it's templates) are designed was not a direct fit for wh
 It Supports the following:
 * Multiple authentication strategies thanks to remix-auth and the verify method (more on this later)
 * User object, access_tokens and refresh_tokens are stored in a cookie
-* `checkSession` method to protect routes and handle refreshing of tokens (if expired)
+* `checkSession` method to protect routes (like `authenticator.isAuthenticated`) and **handle refreshing of tokens** (if expired)
 
 ## How to use
 
-Install the package (and remix-auth)
+### Install the package (and remix-auth)
 * `yarn add remix-auth @afaik/remix-auth-supabase-strategy`
 * `pnpm install remix-auth @afaik/remix-auth-supabase-strategy`
 * `npm install remix-auth @afaik/remix-auth-supabase-strategy`
 
+### Breaking change v2 to v3
+See [Set up a file to export the authenticator(s) and strategy](#set-up-a-file-to-export-the-authenticator-and-strategy)
 
-First setup the sessionStorage
+### Setup the sessionStorage
 ```js
+// app/services/session.server.ts
 import { createCookieSessionStorage } from 'remix'
 
 export const sessionStorage = createCookieSessionStorage({
@@ -49,23 +52,23 @@ export const sessionStorage = createCookieSessionStorage({
 })
 ```
 
-Set up a file to export the authenticator(s) and strategy (i.e: `~/auth.server.ts`)
+### Set up a file to export the authenticator and strategy
 ```js
 // app/auth.server.ts
 import type { Session } from '@supabase/supabase-js'
 import { Authenticator } from 'remix-auth'
 import { SupabaseStrategy } from '@afaik/remix-auth-supabase-strategy'
-import { supabase, supabaseOptions } from '~/utils/supabase'
-import { supabaseAnonKey, supabaseUrl } from '~/config'
+import { supabase } from '~/utils/supabase'
 import { sessionStorage } from '~/session.server'
 
 export const supabaseStrategy = new SupabaseStrategy(
   {
-    supabaseUrl,
-    supabaseOptions,
-    supabaseKey: supabaseAnonKey,
+      supabaseClient: supabase,
+      sessionStorage,
+      sessionKey: 'sb:session', // if not set, default is sb:session
+      sessionErrorKey: 'sb:error', // if not set, default is sb:error
   },
-  async ({ req }) => {
+  async ({ req, supabaseClient }) => {
     // simple verify example for email/password auth
     const form = await req.formData()
     const email = form?.get('email')
@@ -73,7 +76,7 @@ export const supabaseStrategy = new SupabaseStrategy(
     if (!email || typeof email !== 'string' || !password || typeof password !== 'string')
       throw new Error('Need a valid email and/or password')
 
-    return supabase.auth.api.signInWithEmail(email, password).then((res) => {
+    return supabaseClient.auth.api.signInWithEmail(email, password).then((res) => {
       if (res?.error || !res.data)
         throw new Error(res?.error?.message ?? 'No user found')
 
@@ -85,51 +88,119 @@ export const supabaseStrategy = new SupabaseStrategy(
 export const authenticator = new Authenticator<Session>(
   sessionStorage,
   {
-    sessionKey: 'sb:session',
-    sessionErrorKey: 'sb:error'
+      sessionKey: supabaseStrategy.sessionKey, // keep in sync
+      sessionErrorKey: supabaseStrategy.sessionErrorKey, // keep in sync
   })
 
 authenticator.use(supabaseStrategy)
 ```
 
-`~/routes/login.ts`
+### Use SupabaseStrategy to check user session and auto refresh token 🚀
+> `checkSession` works like `authenticator.isAuthenticated` but **handles token refresh**
+
 ```js
-export const loader: LoaderFunction = async({ request }) =>
-  supabaseStrategy.checkSession(
-    request,
-    sessionStorage,
-    {
-      sessionKey: 'sb:session',
-      sessionErrorKey: 'sb:error',
-      successRedirect: '/profile',
-    })
+// app/routes/login.ts
+export const loader: LoaderFunction = async({ request }) => {
+    // If the user is already authenticated, redirect to /profile directly
+    const session = supabaseStrategy.checkSession(request, {
+        successRedirect: '/profile'
+    });
+    
+    if (!session) {
+        // If the user is not authenticated, you can do something or nothing
+        // If you do nothing, /profile page is display
+    }
+}
 
 export const action: ActionFunction = async({ request }) =>
   authenticator.authenticate('sb', request, {
     successRedirect: '/profile',
     failureRedirect: '/login',
   })
+
+export default function LoginPage() {
+    return (
+        <Form method="post">
+            <input type="email" name="email" required />
+            <input
+                type="password"
+                name="password"
+                autoComplete="current-password"
+                required
+            />
+            <button>Sign In</button>
+        </Form>
+    );
+}
 ```
 
-`~/routes/profile.ts`
 ```js
-export const loader: LoaderFunction = async({ request }) =>
-  supabaseStrategy.checkSession(
-    request,
-    sessionStorage,
-    {
-      sessionKey: 'sb:session',
-      sessionErrorKey: 'sb:error',
-      failureRedirect: '/login',
-    })
-
-// handle logout action
-export const action: ActionFunction = async({ request }) => {
-  const session = await sessionStorage.getSession(request.headers.get('Cookie'))
-  return redirect('/', {
-    headers: {
-      'Set-Cookie': await sessionStorage.destroySession(session),
-    },
-  })
+// app/routes/profile.ts
+export const loader: LoaderFunction = async({ request }) => {
+    // If token refresh and successRedirect not set, reload the current route
+    return supabaseStrategy.checkSession(
+        request,
+        {
+            failureRedirect: '/login',
+        })
 }
+  
+
+// Handle logout action
+export const action: ActionFunction = async({ request }) => {
+    await authenticator.logout(request, { redirectTo: "/login" });
+}
+```
+
+##### Get session or redirect
+```js
+// Get the session data or redirect to /login if it failed
+// If token is refreshing and successRedirect not set, it reloads the current route
+const session = await supabaseStrategy.checkSession(request, {
+    failureRedirect: "/login",
+});
+```
+
+##### Redirect if authenticated
+```js
+// If the user is authenticated, redirect to /profile
+await supabaseStrategy.checkSession(request, {
+    successRedirect: "/profile",
+});
+```
+
+##### Get session or null : decide what to do
+```js
+// Get the session or null, and do different things in your loader/action based on
+// the result
+const session = await supabaseStrategy.checkSession(request);
+if (session) {
+    // Here the user is authenticated
+} else {
+    // Here the user is not authenticated
+}
+```
+
+
+### Tips
+#### Prevent infinite loop 😱
+```js
+// app/routes/login.ts
+export const loader: LoaderFunction = async({ request }) => {
+    // Beware, never set failureRedirect equals to the current route
+    const session = supabaseStrategy.checkSession(request, {
+        successRedirect: '/profile',
+        failureRedirect: "/login", // ❌ DONT'T : infinite loop
+    });
+    
+    // In this example, session is always null otherwise it would have been redirected
+}
+
+export const action: ActionFunction = async({ request }) =>
+  authenticator.authenticate('sb', request, {
+    successRedirect: '/profile',
+    failureRedirect: '/login',
+  })
+
+export default function LoginPage() { /* code */}
 ```

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ export default function LoginPage() {
         <Form method="post">
             <input
                 name="redirectTo"
-                value={searchParams.get("redirectTo")}
+                value={searchParams.get("redirectTo") ?? undefined}
                 hidden
                 readOnly
             />

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^1.29.1",
     "add": "^2.0.6",
-    "remix-auth": "^3.1.0"
+    "remix-auth": "^3.2.1"
   },
   "eslintConfig": {
     "extends": "@antfu/eslint-config"

--- a/package.json
+++ b/package.json
@@ -49,10 +49,12 @@
     "formdata-polyfill": "^4.0.10",
     "msw": "^0.36.3",
     "react": "^17.0.2",
-    "remix-auth": "^3.2.1",
     "typescript": "^4.3.5",
     "vite": "^2.7.6",
     "vitest": "^0.0.133"
+  },
+  "dependencies": {
+    "remix-auth": "^3.2.1"
   },
   "eslintConfig": {
     "extends": "@antfu/eslint-config"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@remix-run/node": "^1.0.3",
     "@remix-run/react": "^1.1.1",
     "@remix-run/server-runtime": "^1.0.0",
+    "@supabase/supabase-js": "^1.29.1",
     "@types/faker": "^5.5.9",
     "@types/react": "^17.0.38",
     "@vitest/ui": "^0.0.133",
@@ -48,14 +49,10 @@
     "formdata-polyfill": "^4.0.10",
     "msw": "^0.36.3",
     "react": "^17.0.2",
+    "remix-auth": "^3.2.1",
     "typescript": "^4.3.5",
     "vite": "^2.7.6",
     "vitest": "^0.0.133"
-  },
-  "dependencies": {
-    "@supabase/supabase-js": "^1.29.1",
-    "add": "^2.0.6",
-    "remix-auth": "^3.2.1"
   },
   "eslintConfig": {
     "extends": "@antfu/eslint-config"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ specifiers:
   formdata-polyfill: ^4.0.10
   msw: ^0.36.3
   react: ^17.0.2
-  remix-auth: ^3.1.0
+  remix-auth: ^3.2.1
   typescript: ^4.3.5
   vite: ^2.7.6
   vitest: ^0.0.133
@@ -24,7 +24,7 @@ specifiers:
 dependencies:
   '@supabase/supabase-js': 1.29.1
   add: 2.0.6
-  remix-auth: 3.1.0_969815ef34664ca7c9cb8a3408473b97
+  remix-auth: 3.2.1_969815ef34664ca7c9cb8a3408473b97
 
 devDependencies:
   '@antfu/eslint-config': 0.14.2_eslint@7.32.0+typescript@4.5.4
@@ -3199,8 +3199,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /remix-auth/3.1.0_969815ef34664ca7c9cb8a3408473b97:
-    resolution: {integrity: sha512-KWBLV5pr0jOCuXjhZp1LHEtG9SR1SuLLzkI9MZuzg/un6P6edA9EKzT5LMQRHGoyiRDZ100wgMj8Dd0mw6950A==}
+  /remix-auth/3.2.1_969815ef34664ca7c9cb8a3408473b97:
+    resolution: {integrity: sha512-5N5ZjKCYGjbRmMi9PQwngKuuGkBEfny0Q4iXyTrDxQhSzAbQ/+wHX+ZKGdneYWHULZJCRZbjSmyrjk/rJxGFlw==}
     peerDependencies:
       '@remix-run/react': ^1.0.0
       '@remix-run/server-runtime': ^1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ specifiers:
   vite: ^2.7.6
   vitest: ^0.0.133
 
+dependencies:
+  remix-auth: 3.2.1_969815ef34664ca7c9cb8a3408473b97
+
 devDependencies:
   '@antfu/eslint-config': 0.14.2_eslint@7.32.0+typescript@4.5.4
   '@remix-run/node': 1.1.1_react@17.0.2
@@ -35,7 +38,6 @@ devDependencies:
   formdata-polyfill: 4.0.10
   msw: 0.36.3
   react: 17.0.2
-  remix-auth: 3.2.1_969815ef34664ca7c9cb8a3408473b97
   typescript: 4.5.4
   vite: 2.7.10
   vitest: 0.0.133_@vitest+ui@0.0.133+c8@7.11.0
@@ -3206,7 +3208,7 @@ packages:
       uuid: 8.3.2
     transitivePeerDependencies:
       - react
-    dev: true
+    dev: false
 
   /remix-utils/2.4.0_969815ef34664ca7c9cb8a3408473b97:
     resolution: {integrity: sha512-qwzlPwjvRHIrPULnl7AFZAbjku6sihid2412QLMc8bPC6mm1XpUKnJtebW30WtO6wgwQu2CAwhIFQ2HsBQLXTw==}
@@ -3221,7 +3223,7 @@ packages:
       react: 17.0.2
       type-fest: 2.8.0
       uuid: 8.3.2
-    dev: true
+    dev: false
 
   /require-directory/2.1.1:
     resolution: {integrity: sha1-jGStX9MNqxyXbiNE/+f3kqam30I=}
@@ -3661,7 +3663,7 @@ packages:
   /type-fest/2.8.0:
     resolution: {integrity: sha512-O+V9pAshf9C6loGaH0idwsmugI2LxVNR7DtS40gVo2EXZVYFgz9OuNtOhgHLdHdapOEWNdvz9Ob/eeuaWwwlxA==}
     engines: {node: '>=12.20'}
-    dev: true
+    dev: false
 
   /type/1.2.0:
     resolution: {integrity: sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==}
@@ -3724,7 +3726,7 @@ packages:
   /uuid/8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
-    dev: true
+    dev: false
 
   /v8-compile-cache/2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,6 @@ specifiers:
   '@types/faker': ^5.5.9
   '@types/react': ^17.0.38
   '@vitest/ui': ^0.0.133
-  add: ^2.0.6
   c8: ^7.10.0
   eslint: ^7.26.0
   faker: 5.5.3
@@ -21,16 +20,12 @@ specifiers:
   vite: ^2.7.6
   vitest: ^0.0.133
 
-dependencies:
-  '@supabase/supabase-js': 1.29.1
-  add: 2.0.6
-  remix-auth: 3.2.1_969815ef34664ca7c9cb8a3408473b97
-
 devDependencies:
   '@antfu/eslint-config': 0.14.2_eslint@7.32.0+typescript@4.5.4
   '@remix-run/node': 1.1.1_react@17.0.2
   '@remix-run/react': 1.1.1_react@17.0.2
   '@remix-run/server-runtime': 1.1.1_react@17.0.2
+  '@supabase/supabase-js': 1.29.1
   '@types/faker': 5.5.9
   '@types/react': 17.0.38
   '@vitest/ui': 0.0.133
@@ -40,6 +35,7 @@ devDependencies:
   formdata-polyfill: 4.0.10
   msw: 0.36.3
   react: 17.0.2
+  remix-auth: 3.2.1_969815ef34664ca7c9cb8a3408473b97
   typescript: 4.5.4
   vite: 2.7.10
   vitest: 0.0.133_@vitest+ui@0.0.133+c8@7.11.0
@@ -495,26 +491,26 @@ packages:
     resolution: {integrity: sha512-YnL4cO3Q+ugatWEtgCEnLt+Wwi0VpOVTPSSjSSUho2x3cH7+juRBTrVbYky/W6YVgAw/ZJrVUFPh/NcUCUhdmw==}
     dependencies:
       cross-fetch: 3.1.4
-    dev: false
+    dev: true
 
   /@supabase/postgrest-js/0.35.0:
     resolution: {integrity: sha512-z+XKJ2oXuGEAEBVXseeQUXaM3ekQZK4XF0Kc399Glyg+rZaBTwNeJtY+Q/23NcIE5uNMYbTnEXm80jZbLBnWdw==}
     dependencies:
       cross-fetch: 3.1.4
-    dev: false
+    dev: true
 
   /@supabase/realtime-js/1.3.4:
     resolution: {integrity: sha512-N9xerTleMp6OKgsqYp0WujYJvKplMxhSJ9agTvAL6vc/+4hh5uxak4wLpgqigy3ZBzpRUSYty7hDyS017+waiw==}
     dependencies:
       '@types/websocket': 1.0.4
       websocket: 1.0.34
-    dev: false
+    dev: true
 
   /@supabase/storage-js/1.5.0:
     resolution: {integrity: sha512-ki2HT9FrCYRN3yoqWqX+u47TUHQ8lgSStAqV/97kMov1z2d+iIlqGBGVcaGDqq4NvK8CipG8IJARYM72oX+afA==}
     dependencies:
       cross-fetch: 3.1.4
-    dev: false
+    dev: true
 
   /@supabase/supabase-js/1.29.1:
     resolution: {integrity: sha512-5UPgB93XCzALTpbuwvEGH+Y7i3YBY3y3y96uNnzAWYerGWlqx2kIVmV++GAiEPp/tp+QRsv103AoLKiP3dP2DA==}
@@ -523,7 +519,7 @@ packages:
       '@supabase/postgrest-js': 0.35.0
       '@supabase/realtime-js': 1.3.4
       '@supabase/storage-js': 1.5.0
-    dev: false
+    dev: true
 
   /@types/busboy/0.3.1:
     resolution: {integrity: sha512-8BPLNy4x+7lbTOGkAyUIZrrPEZ7WzbO7YlVGMf9EZi9J9mqILEkYbt/kgVWQ7fizOISo1hM/7cAsWVTa7EhQDg==}
@@ -581,6 +577,7 @@ packages:
 
   /@types/node/17.0.7:
     resolution: {integrity: sha512-1QUk+WAUD4t8iR+Oj+UgI8oJa6yyxaB8a8pHaC8uqM6RrS1qbL7bf3Pwl5rHv0psm2CuDErgho6v5N+G+5fwtQ==}
+    dev: true
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -618,7 +615,7 @@ packages:
     resolution: {integrity: sha512-qn1LkcFEKK8RPp459jkjzsfpbsx36BBt3oC3pITYtkoBw/aVX+EZFa5j3ThCRTNpLFvIMr5dSTD4RaMdilIOpA==}
     dependencies:
       '@types/node': 17.0.7
-    dev: false
+    dev: true
 
   /@typescript-eslint/eslint-plugin/5.9.0_c05e6fca5974c04442e7c260534af929:
     resolution: {integrity: sha512-qT4lr2jysDQBQOPsCCvpPUZHjbABoTJW8V9ZzIYKHMfppJtpdtzszDYsldwhFxlhvrp7aCHeXD1Lb9M1zhwWwQ==}
@@ -817,10 +814,6 @@ packages:
     hasBin: true
     dev: true
 
-  /add/2.0.6:
-    resolution: {integrity: sha1-JI8Kn25aUo7yKV2+7DBTITCuIjU=}
-    dev: false
-
   /ajv/6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
     dependencies:
@@ -1006,7 +999,7 @@ packages:
     requiresBuild: true
     dependencies:
       node-gyp-build: 4.3.0
-    dev: false
+    dev: true
 
   /builtin-modules/3.2.0:
     resolution: {integrity: sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==}
@@ -1208,7 +1201,7 @@ packages:
     resolution: {integrity: sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==}
     dependencies:
       node-fetch: 2.6.1
-    dev: false
+    dev: true
 
   /cross-spawn/7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
@@ -1228,12 +1221,13 @@ packages:
     dependencies:
       es5-ext: 0.10.53
       type: 1.2.0
-    dev: false
+    dev: true
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     dependencies:
       ms: 2.0.0
+    dev: true
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -1408,7 +1402,7 @@ packages:
       es6-iterator: 2.0.3
       es6-symbol: 3.1.3
       next-tick: 1.0.0
-    dev: false
+    dev: true
 
   /es6-iterator/2.0.3:
     resolution: {integrity: sha1-p96IkUGgWpSwhUQDstCg+/qY87c=}
@@ -1416,14 +1410,14 @@ packages:
       d: 1.0.1
       es5-ext: 0.10.53
       es6-symbol: 3.1.3
-    dev: false
+    dev: true
 
   /es6-symbol/3.1.3:
     resolution: {integrity: sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==}
     dependencies:
       d: 1.0.1
       ext: 1.6.0
-    dev: false
+    dev: true
 
   /esbuild-android-arm64/0.13.15:
     resolution: {integrity: sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==}
@@ -1973,7 +1967,7 @@ packages:
     resolution: {integrity: sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==}
     dependencies:
       type: 2.5.0
-    dev: false
+    dev: true
 
   /external-editor/3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
@@ -2500,7 +2494,7 @@ packages:
 
   /is-typedarray/1.0.0:
     resolution: {integrity: sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=}
-    dev: false
+    dev: true
 
   /is-unicode-supported/0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
@@ -2752,6 +2746,7 @@ packages:
 
   /ms/2.0.0:
     resolution: {integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=}
+    dev: true
 
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -2810,12 +2805,12 @@ packages:
 
   /next-tick/1.0.0:
     resolution: {integrity: sha1-yobR/ogoFpsBICCOPchCS524NCw=}
-    dev: false
+    dev: true
 
   /node-fetch/2.6.1:
     resolution: {integrity: sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==}
     engines: {node: 4.x || >=6.0.0}
-    dev: false
+    dev: true
 
   /node-fetch/2.6.6:
     resolution: {integrity: sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==}
@@ -2827,7 +2822,7 @@ packages:
   /node-gyp-build/4.3.0:
     resolution: {integrity: sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==}
     hasBin: true
-    dev: false
+    dev: true
 
   /node-releases/2.0.1:
     resolution: {integrity: sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==}
@@ -3211,7 +3206,7 @@ packages:
       uuid: 8.3.2
     transitivePeerDependencies:
       - react
-    dev: false
+    dev: true
 
   /remix-utils/2.4.0_969815ef34664ca7c9cb8a3408473b97:
     resolution: {integrity: sha512-qwzlPwjvRHIrPULnl7AFZAbjku6sihid2412QLMc8bPC6mm1XpUKnJtebW30WtO6wgwQu2CAwhIFQ2HsBQLXTw==}
@@ -3226,7 +3221,7 @@ packages:
       react: 17.0.2
       type-fest: 2.8.0
       uuid: 8.3.2
-    dev: false
+    dev: true
 
   /require-directory/2.1.1:
     resolution: {integrity: sha1-jGStX9MNqxyXbiNE/+f3kqam30I=}
@@ -3666,21 +3661,21 @@ packages:
   /type-fest/2.8.0:
     resolution: {integrity: sha512-O+V9pAshf9C6loGaH0idwsmugI2LxVNR7DtS40gVo2EXZVYFgz9OuNtOhgHLdHdapOEWNdvz9Ob/eeuaWwwlxA==}
     engines: {node: '>=12.20'}
-    dev: false
+    dev: true
 
   /type/1.2.0:
     resolution: {integrity: sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==}
-    dev: false
+    dev: true
 
   /type/2.5.0:
     resolution: {integrity: sha512-180WMDQaIMm3+7hGXWf12GtdniDEy7nYcyFMKJn/eZz/6tSLXrUN9V0wKSbMjej0I1WHWbpREDEKHtqPQa9NNw==}
-    dev: false
+    dev: true
 
   /typedarray-to-buffer/3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
     dependencies:
       is-typedarray: 1.0.0
-    dev: false
+    dev: true
 
   /typescript/4.5.4:
     resolution: {integrity: sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==}
@@ -3709,7 +3704,7 @@ packages:
     requiresBuild: true
     dependencies:
       node-gyp-build: 4.3.0
-    dev: false
+    dev: true
 
   /util-deprecate/1.0.2:
     resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=}
@@ -3729,7 +3724,7 @@ packages:
   /uuid/8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
-    dev: false
+    dev: true
 
   /v8-compile-cache/2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
@@ -3860,7 +3855,7 @@ packages:
       typedarray-to-buffer: 3.1.5
       utf-8-validate: 5.0.8
       yaeti: 0.0.6
-    dev: false
+    dev: true
 
   /whatwg-url/5.0.0:
     resolution: {integrity: sha1-lmRU6HZUYuN2RNNib2dCzotwll0=}
@@ -3925,7 +3920,7 @@ packages:
   /yaeti/0.0.6:
     resolution: {integrity: sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=}
     engines: {node: '>=0.10.32'}
-    dev: false
+    dev: true
 
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,10 +44,11 @@ export interface VerifyParams {
 export class SupabaseStrategy extends
   Strategy<Session, VerifyParams> {
   name = 'sb'
+  readonly sessionKey: string
+  readonly sessionErrorKey: string
+
   private readonly supabaseClient: SupabaseClient
   private readonly sessionStorage: SessionStorage
-  private readonly sessionKey: string
-  private readonly sessionErrorKey: string
 
   constructor(
     options: SupabaseStrategyOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,11 @@ export interface VerifyParams {
   readonly supabaseClient: SupabaseClient
 }
 
+export type CheckOptions =
+    | { successRedirect?: never; failureRedirect?: never }
+    | { successRedirect: string; failureRedirect?: never }
+    | { successRedirect?: never; failureRedirect: string }
+
 export class SupabaseStrategy extends
   Strategy<Session, VerifyParams> {
   name = 'sb'
@@ -130,10 +135,7 @@ export class SupabaseStrategy extends
     failureRedirect?: never
   }): Promise<Session | null>
 
-  async checkSession(req: Request, checkOptions:
-  | { successRedirect?: never; failureRedirect?: never }
-  | { successRedirect: string; failureRedirect?: never }
-  | { successRedirect?: never; failureRedirect: string } = {}): Promise<Session | null> {
+  async checkSession(req: Request, checkOptions: CheckOptions = {}): Promise<Session | null> {
     const sessionCookie = await this.sessionStorage.getSession(req.headers.get('Cookie'))
     const session: Session | null = sessionCookie.get(this.sessionKey)
     const options = { sessionKey: this.sessionKey, sessionErrorKey: this.sessionErrorKey, ...checkOptions }

--- a/src/mocks/authenticator.ts
+++ b/src/mocks/authenticator.ts
@@ -6,7 +6,7 @@ import { SESSION_ERROR_KEY, SESSION_KEY } from './constants'
 import { sessionStorage } from './sessionStorage'
 import { supabaseClient } from './supabase'
 
-const verify = async({ req, supabaseClient }: VerifyParams) => {
+export const verify = async({ req, supabaseClient }: VerifyParams) => {
   const form = await req.formData()
   const email = form.get('email')
   const password = form.get('password')

--- a/src/mocks/authenticator.ts
+++ b/src/mocks/authenticator.ts
@@ -2,11 +2,11 @@ import type { AuthSession } from '@supabase/supabase-js'
 import { Authenticator } from 'remix-auth'
 import type { VerifyParams } from '..'
 import { SupabaseStrategy } from '..'
-import { SESSION_ERROR_KEY, SESSION_KEY, SUPABASE_KEY, SUPABASE_URL } from './constants'
+import { SESSION_ERROR_KEY, SESSION_KEY } from './constants'
 import { sessionStorage } from './sessionStorage'
 import { supabaseClient } from './supabase'
 
-const verify = async({ req }: VerifyParams) => {
+const verify = async({ req, supabaseClient }: VerifyParams) => {
   const form = await req.formData()
   const email = form.get('email')
   const password = form.get('password')
@@ -21,8 +21,8 @@ const verify = async({ req }: VerifyParams) => {
 }
 
 export const supabaseStrategy = new SupabaseStrategy({
-  supabaseUrl: SUPABASE_URL,
-  supabaseKey: SUPABASE_KEY,
+  supabaseClient,
+  sessionStorage,
 }, verify)
 
 export const authenticator = new Authenticator<AuthSession>(

--- a/src/mocks/requests.ts
+++ b/src/mocks/requests.ts
@@ -8,5 +8,5 @@ export const authenticatedReq = async(init: Request = req, cookieInit?: CookieIn
 
   const headersInit: HeadersInit | undefined = res?.headers?.get('Cookie') ? { Cookie: res.headers.get('Cookie') as string } : undefined
 
-  return new Request('', { headers: headersInit })
+  return new Request(init, { headers: headersInit })
 }

--- a/src/test/checkSession.test.ts
+++ b/src/test/checkSession.test.ts
@@ -7,12 +7,15 @@ import { validResponse } from '../mocks/handlers'
 
 describe('[external export] revalidate', async() => {
   it('should redirect if cookie is not set', async() => {
-    expect.assertions(1)
+    expect.assertions(2)
     await supabaseStrategy.checkSession(new Request(''),
       {
         failureRedirect: '/login',
       },
-    ).catch(res => expect(res.status).toBe(302))
+    ).catch((res) => {
+      expect(res.status).toBe(302)
+      expect(res.headers.get('Location')).toEqual('/login')
+    })
   })
   it('should return null if no cookie is set', async() => {
     expect.assertions(1)

--- a/src/test/strategy.test.ts
+++ b/src/test/strategy.test.ts
@@ -1,0 +1,22 @@
+import { SupabaseStrategy } from '../index'
+import { supabaseClient } from '../mocks/supabase'
+import { sessionStorage } from '../mocks/sessionStorage'
+
+describe('strategy', async() => {
+  it('should throw if missing supabaseClient', async() => {
+    // @ts-ignore
+    expect(() => new SupabaseStrategy()).toThrow('SupabaseStrategy : Constructor expected to receive a supabase client instance. Missing options.supabaseClient')
+  })
+  it('should throw if missing sessionStorage', async() => {
+    // @ts-ignore
+    expect(() => new SupabaseStrategy({ supabaseClient })).toThrow('SupabaseStrategy : Constructor expected to receive a session storage instance. Missing options.sessionStorage')
+  })
+  it('should throw if missing verify function', async() => {
+    // @ts-ignore
+    expect(() => new SupabaseStrategy({ supabaseClient, sessionStorage })).toThrow('SupabaseStrategy : Constructor expected to receive a verify function. Missing verify')
+  })
+  it('should throw if missing verify function', async() => {
+    // @ts-ignore
+    expect(() => new SupabaseStrategy({ supabaseClient, sessionStorage }, () => {})).not.toThrow()
+  })
+})

--- a/src/test/strategy.test.ts
+++ b/src/test/strategy.test.ts
@@ -1,39 +1,31 @@
 import { SupabaseStrategy } from '../index'
 import { supabaseClient } from '../mocks/supabase'
 import { sessionStorage } from '../mocks/sessionStorage'
+import { verify } from '../mocks/authenticator'
 
-describe('strategy', async() => {
-  it('should throw if missing supabaseClient', async() => {
-    expect.assertions(1)
-    // @ts-ignore
+describe('strategy', () => {
+  it('should throw if missing supabaseClient', () => {
+    // @ts-expect-error
     expect(() => new SupabaseStrategy()).toThrow('SupabaseStrategy : Constructor expected to receive a supabase client instance. Missing options.supabaseClient')
   })
-  it('should throw if missing sessionStorage', async() => {
-    expect.assertions(1)
-    // @ts-ignore
+  it('should throw if missing sessionStorage', () => {
+    // @ts-expect-error
     expect(() => new SupabaseStrategy({ supabaseClient })).toThrow('SupabaseStrategy : Constructor expected to receive a session storage instance. Missing options.sessionStorage')
   })
-  it('should throw if missing verify function', async() => {
-    expect.assertions(1)
-    // @ts-ignore
+  it('should throw if missing verify function', () => {
+    // @ts-expect-error
     expect(() => new SupabaseStrategy({ supabaseClient, sessionStorage })).toThrow('SupabaseStrategy : Constructor expected to receive a verify function. Missing verify')
   })
-  it('should throw if missing verify function', async() => {
-    expect.assertions(1)
-    // @ts-ignore
-    expect(() => new SupabaseStrategy({ supabaseClient, sessionStorage }, () => {})).not.toThrow()
+  it('should provide an instance', () => {
+    expect(() => new SupabaseStrategy({ supabaseClient, sessionStorage }, verify)).not.toThrow()
   })
-  it('should strategy provides default sessionKey and sessionErrorKey', async() => {
-    expect.assertions(2)
-    // @ts-ignore
-    const supabaseStrategy = new SupabaseStrategy({ supabaseClient, sessionStorage }, () => {})
+  it('should provide a default sessionKey and sessionErrorKey', () => {
+    const supabaseStrategy = new SupabaseStrategy({ supabaseClient, sessionStorage }, verify)
     expect(supabaseStrategy.sessionKey).toBe('sb:session')
     expect(supabaseStrategy.sessionErrorKey).toBe('sb:error')
   })
-  it('should strategy provides custom sessionKey and sessionErrorKey', async() => {
-    expect.assertions(2)
-    // @ts-ignore
-    const supabaseStrategy = new SupabaseStrategy({ supabaseClient, sessionStorage, sessionKey: '__session', sessionErrorKey: '__error' }, () => {})
+  it('should provide a custom sessionKey and sessionErrorKey', () => {
+    const supabaseStrategy = new SupabaseStrategy({ supabaseClient, sessionStorage, sessionKey: '__session', sessionErrorKey: '__error' }, verify)
     expect(supabaseStrategy.sessionKey).toBe('__session')
     expect(supabaseStrategy.sessionErrorKey).toBe('__error')
   })

--- a/src/test/strategy.test.ts
+++ b/src/test/strategy.test.ts
@@ -4,19 +4,37 @@ import { sessionStorage } from '../mocks/sessionStorage'
 
 describe('strategy', async() => {
   it('should throw if missing supabaseClient', async() => {
+    expect.assertions(1)
     // @ts-ignore
     expect(() => new SupabaseStrategy()).toThrow('SupabaseStrategy : Constructor expected to receive a supabase client instance. Missing options.supabaseClient')
   })
   it('should throw if missing sessionStorage', async() => {
+    expect.assertions(1)
     // @ts-ignore
     expect(() => new SupabaseStrategy({ supabaseClient })).toThrow('SupabaseStrategy : Constructor expected to receive a session storage instance. Missing options.sessionStorage')
   })
   it('should throw if missing verify function', async() => {
+    expect.assertions(1)
     // @ts-ignore
     expect(() => new SupabaseStrategy({ supabaseClient, sessionStorage })).toThrow('SupabaseStrategy : Constructor expected to receive a verify function. Missing verify')
   })
   it('should throw if missing verify function', async() => {
+    expect.assertions(1)
     // @ts-ignore
     expect(() => new SupabaseStrategy({ supabaseClient, sessionStorage }, () => {})).not.toThrow()
+  })
+  it('should strategy provides default sessionKey and sessionErrorKey', async() => {
+    expect.assertions(2)
+    // @ts-ignore
+    const supabaseStrategy = new SupabaseStrategy({ supabaseClient, sessionStorage }, () => {})
+    expect(supabaseStrategy.sessionKey).toBe('sb:session')
+    expect(supabaseStrategy.sessionErrorKey).toBe('sb:error')
+  })
+  it('should strategy provides custom sessionKey and sessionErrorKey', async() => {
+    expect.assertions(2)
+    // @ts-ignore
+    const supabaseStrategy = new SupabaseStrategy({ supabaseClient, sessionStorage, sessionKey: '__session', sessionErrorKey: '__error' }, () => {})
+    expect(supabaseStrategy.sessionKey).toBe('__session')
+    expect(supabaseStrategy.sessionErrorKey).toBe('__error')
   })
 })


### PR DESCRIPTION
What's new : 

remix-auth updated to last version

Readme up to date with new strategy configuration

New constructor that receives : 
- SupabaseClient
- SessionStorage
- sessionKey (optional, default is sb:session
- sessionErrorKey (optional, default is sb:error

checkSession : 
- only require Request
- checkOptions (optional) with successRedirect and or failureRedirect
- act like authenticator.isAuthenticated (same function signature)
- on token refresh,  if successRedirect not set, redirect to current route

handleResult : 
- when hasErrored, return null to feat authenticator.isAuthenticated behaviour

Tested on JS and TS projects

Ref : https://github.com/mitchelvanbever/remix-auth-supabase-strategy/issues/4